### PR TITLE
ex_syslogger has problems when part of a larger application with releases

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,8 @@ defmodule ExSyslogger.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:syslog, :logger, :poison]]
+    [applications: [:logger, :poison],
+     included_applications: [:syslog]]
   end
 
   defp description do


### PR DESCRIPTION
**Problem**

When you add ex_syslogger as part of a larger application using a release manager like distillery/exrm :syslog can be started twice and depending on where you place :ex_syslogger in the list of applications/included_applications this can crash your application or cause a DRV_IN_USE error message which doesn't crash the app but is still an issue.

**Solution**

In this case I feel the :logger application should be responsible for starting :syslog as really they are only needed when you have an :ex_syslogger backend configured. 

With this "code" change syslog is only started when you have a configured syslogger backend, it is started once by logger (in the init function). 

**EDIT**

I noticed somebody over at the original project this was forked from posed a similar fix:

https://github.com/22cans/exsyslog/pull/6
