### PR TITLE
Remove poison from the list of application

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ def application do
 end
 ```
 
+If you going to use JsonFormatter please we sure that `poison` is added as dependency in your application. For older Elixir versions it might be needed to add it to the list of applications as above.
+
 ## Configuration
 
 ExSyslogger is a Logger custom backend, as such, it relies on [Logger](http://elixir-lang.org/docs/stable/logger/) application.

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule ExSyslogger.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger, :poison], included_applications: [:syslog]]
+    [applications: [:logger], included_applications: [:syslog]]
   end
 
   defp description do


### PR DESCRIPTION
This fixes the problem when ex_sysloger is used in an application where is
no Posion. Since JSON formatting is marked as optional we shouldn't push
users to include it into the release.