### PR TITLE
Accepts value :all for :metadata backend configuration.

### DIFF
--- a/lib/ex_syslogger.ex
+++ b/lib/ex_syslogger.ex
@@ -265,7 +265,10 @@ defmodule ExSyslogger do
                     %{format: format,
                       formatter: Logger.Formatter,
                       metadata: config_metadata}) do
-    metadata = metadata |> Keyword.take(config_metadata)
+    metadata =
+      if config_metadata == :all,
+        do: metadata,
+        else: Keyword.take(metadata, config_metadata)
 
     format
     |> Logger.Formatter.format(level, msg, timestamp, metadata)


### PR DESCRIPTION
Addresses https://github.com/slashmili/ex_syslogger/issues/14

Following the same approach implemented in [Elixir.Logger.Backends.Console](https://github.com/elixir-lang/elixir/blob/master/lib/logger/lib/logger/backends/console.ex#L190) to allow `:all` as `:metadata` backend configuration.

Example:

```elixir
config :logger,
  backends: [:console, {Elixir.ExSyslogger, :ex_syslogger}]

config :logger, :console,
  metadata: :all

config :logger, :ex_syslogger,
  metadata: :all
```

Before this patch the following crash errors is shown when using `metadata: :all` backend config:
```
20:17:25.790 [error] CRASH REPORT Process <0.10004.0> with 0 neighbours exited with reason: {'EXIT',{#{'__exception__' => true,'__struct__' => 'Elixir.Protocol.UndefinedError',description => <<>>,protocol => 'Elixir.Enumerable',value => all},[{'Elixir.Enumerable','impl_for!',1,[{file,"/Users/jose/OSS/elixir/lib/elixir/lib/enum.ex"},{line,1}]},{'Elixir.Enumerable','member?',2,[{file,"/Users/jose/OSS/elixir/lib/elixir/lib/enum.ex"},{line,166}]},{'Elixir.Enum','member?',2,[{file,"lib/enum.ex"},{line,1553}]},{'Elixir.Keyword','-take/2-lists^filter/1-0-',2,[{file,"lib/keyword.ex"},{line,...}]},...]}} in gen_server:handle_common_reply/8 line 751
20:17:25.790 [error] Supervisor 'Elixir.Logger.BackendSupervisor' had child {'Elixir.ExSyslogger',ex_syslogger} started with 'Elixir.Logger.Watcher':start_link({'Elixir.Logger',{'Elixir.ExSyslogger',ex_syslogger},{'Elixir.ExSyslogger',ex_syslogger}}) at <0.10004.0> exit with reason {'EXIT',{#{'__exception__' => true,'__struct__' => 'Elixir.Protocol.UndefinedError',description => <<>>,protocol => 'Elixir.Enumerable',value => all},[{'Elixir.Enumerable','impl_for!',1,[{file,"/Users/jose/OSS/elixir/lib/elixir/lib/enum.ex"},{line,1}]},{'Elixir.Enumerable','member?',2,[{file,"/Users/jose/OSS/elixir/lib/elixir/lib/enum.ex"},{line,166}]},{'Elixir.Enum','member?',2,[{file,"lib/enum.ex"},{line,1553}]},{'Elixir.Keyword','-take/2-lists^filter/1-0-',2,[{file,"lib/keyword.ex"},{line,...}]},...]}} in context child_terminated
:gen_event handler {ExSyslogger, :ex_syslogger} installed in Logger terminating
** (exit) an exception was raised:
    ** (Protocol.UndefinedError) protocol Enumerable not implemented for :all. This protocol is implemented for: Ecto.Adapters.SQL.Stream, Postgrex.Stream, DBConnection.PrepareStream, DBConnection.Stream, Timex.Interval, Date.Range, File.Stream, Function, GenEvent.Stream, HashDict, HashSet, IO.Stream, List, Map, MapSet, Range, Stream
        (elixir) /Users/jose/OSS/elixir/lib/elixir/lib/enum.ex:1: Enumerable.impl_for!/1
        (elixir) /Users/jose/OSS/elixir/lib/elixir/lib/enum.ex:166: Enumerable.member?/2
        (elixir) lib/enum.ex:1553: Enum.member?/2
        (elixir) lib/keyword.ex:927: Keyword."-take/2-lists^filter/1-0-"/2
        (ex_syslogger) lib/ex_syslogger.ex:268: ExSyslogger.format_event/5
        (ex_syslogger) lib/ex_syslogger.ex:215: ExSyslogger.handle_event/2
        (stdlib) gen_event.erl:577: :gen_event.server_update/4
        (stdlib) gen_event.erl:559: :gen_event.server_notify/4
        (stdlib) gen_event.erl:300: :gen_event.handle_msg/6
        (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```

```
=ERROR REPORT==== 14-Apr-2020::17:27:02.607747 ===
** Generic server <0.921.0> terminating
** Last message in was {gen_event_EXIT,
                        {'Elixir.ExSyslogger',ex_syslogger},
                        {'EXIT',
                         {#{'__exception__' => true,
                            '__struct__' => 'Elixir.Protocol.UndefinedError',
                            description => <<>>,
                            protocol => 'Elixir.Enumerable',value => all},
                          [{'Elixir.Enumerable','impl_for!',1,
                            [{file,
                              "/home/build/elixir/lib/elixir/lib/enum.ex"},
                             {line,1}]},
                           {'Elixir.Enumerable','member?',2,
                            [{file,
                              "/home/build/elixir/lib/elixir/lib/enum.ex"},
                             {line,166}]},
                           {'Elixir.Enum','member?',2,
                            [{file,"lib/enum.ex"},{line,1553}]},
                           {'Elixir.Keyword','-take/2-lists^filter/1-0-',2,
                            [{file,"lib/keyword.ex"},{line,927}]},
                           {'Elixir.ExSyslogger',format_event,5,
                            [{file,"lib/ex_syslogger.ex"},{line,268}]},
                           {'Elixir.ExSyslogger',handle_event,2,
                            [{file,"lib/ex_syslogger.ex"},{line,215}]},
                           {gen_event,server_update,4,
                            [{file,"gen_event.erl"},{line,577}]},
                           {gen_event,server_notify,4,
                            [{file,"gen_event.erl"},{line,559}]},
                           {gen_event,handle_msg,6,
                            [{file,"gen_event.erl"},{line,300}]},
                           {proc_lib,init_p_do_apply,3,
                            [{file,"proc_lib.erl"},{line,249}]}]}}}
** When Server state == {'Elixir.Logger',{'Elixir.ExSyslogger',ex_syslogger}}
** Reason for termination ==
** {'EXIT',
       {#{'__exception__' => true,
          '__struct__' => 'Elixir.Protocol.UndefinedError',
          description => <<>>,protocol => 'Elixir.Enumerable',value => all},
        [{'Elixir.Enumerable','impl_for!',1,
             [{file,"/home/build/elixir/lib/elixir/lib/enum.ex"},{line,1}]},
         {'Elixir.Enumerable','member?',2,
             [{file,"/home/build/elixir/lib/elixir/lib/enum.ex"},{line,166}]},
         {'Elixir.Enum','member?',2,[{file,"lib/enum.ex"},{line,1553}]},
         {'Elixir.Keyword','-take/2-lists^filter/1-0-',2,
             [{file,"lib/keyword.ex"},{line,927}]},
         {'Elixir.ExSyslogger',format_event,5,
             [{file,"lib/ex_syslogger.ex"},{line,268}]},
         {'Elixir.ExSyslogger',handle_event,2,
             [{file,"lib/ex_syslogger.ex"},{line,215}]},
         {gen_event,server_update,4,[{file,"gen_event.erl"},{line,577}]},
         {gen_event,server_notify,4,[{file,"gen_event.erl"},{line,559}]},
         {gen_event,handle_msg,6,[{file,"gen_event.erl"},{line,300}]},
         {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,249}]}]}}

=CRASH REPORT==== 14-Apr-2020::17:27:02.608105 ===
  crasher:
    initial call: Elixir.Logger.Watcher:init/1
    pid: <0.921.0>
    registered_name: []
    exception exit: {'EXIT',
                        {#{'__exception__' => true,
                           '__struct__' => 'Elixir.Protocol.UndefinedError',
                           description => <<>>,
                           protocol => 'Elixir.Enumerable',value => all},
                         [{'Elixir.Enumerable','impl_for!',1,
                              [{file,
                                   "/home/build/elixir/lib/elixir/lib/enum.ex"},
                               {line,1}]},
                          {'Elixir.Enumerable','member?',2,
                              [{file,
                                   "/home/build/elixir/lib/elixir/lib/enum.ex"},
                               {line,166}]},
                          {'Elixir.Enum','member?',2,
                              [{file,"lib/enum.ex"},{line,1553}]},
                          {'Elixir.Keyword','-take/2-lists^filter/1-0-',2,
                              [{file,"lib/keyword.ex"},{line,927}]},
                          {'Elixir.ExSyslogger',format_event,5,
                              [{file,"lib/ex_syslogger.ex"},{line,268}]},
                          {'Elixir.ExSyslogger',handle_event,2,
                              [{file,"lib/ex_syslogger.ex"},{line,215}]},
                          {gen_event,server_update,4,
                              [{file,"gen_event.erl"},{line,577}]},
                          {gen_event,server_notify,4,
                              [{file,"gen_event.erl"},{line,559}]},
                          {gen_event,handle_msg,6,
                              [{file,"gen_event.erl"},{line,300}]},
                          {proc_lib,init_p_do_apply,3,
                              [{file,"proc_lib.erl"},{line,249}]}]}}
      in function  gen_server:handle_common_reply/8 (gen_server.erl, line 751)
    ancestors: ['Elixir.Logger.BackendSupervisor',
                  'Elixir.Logger.Supervisor',<0.323.0>]
    message_queue_len: 0
    messages: []
    links: [<0.327.0>,<0.325.0>]
    dictionary: []
    trap_exit: true
    status: running
    heap_size: 17731
    stack_size: 27
    reductions: 28770
```