### PR TITLE
Fix Deprecations, Warnings & Format

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
@@ -22,6 +22,6 @@ use Mix.Config
 # here (which is why it is important to import them last).
 #
 
-import_config "#{Mix.env}.exs"
+import_config "#{config_env()}.exs"
 
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,11 +1,11 @@
-use Mix.Config
+import Config
 
 config :logger,
   utc_log: true,
   truncate: 8192,
   sync_threshold: 40,
   discard_threshold_for_error_logger: 500,
-  compile_time_purge_level: :debug,
+  compile_time_purge_matching: [[level_lower_than: :debug]],
   backends: [
             {ExSyslogger, :ex_syslogger_error},
             {ExSyslogger, :ex_syslogger_debug},

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+import Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,11 +1,11 @@
-use Mix.Config
+import Config
 
 config :logger,
   utc_log: true,
   truncate: 8192,
   sync_threshold: 40,
   discard_threshold_for_error_logger: 500,
-  compile_time_purge_level: :debug,
+  compile_time_purge_matching: [[level_lower_than: :debug]],
   backends: [
             {ExSyslogger, :ex_syslogger_error},
             {ExSyslogger, :ex_syslogger_debug},

--- a/examples/example1/config/config.exs
+++ b/examples/example1/config/config.exs
@@ -28,7 +28,7 @@ config :logger,
   truncate: 8192,
   sync_threshold: 40,
   discard_threshold_for_error_logger: 500,
-  compile_time_purge_level: :debug,
+  compile_time_purge_matching: [[level_lower_than: :debug]],
   backends: [
             :console,
             {ExSyslogger, :ex_syslogger_error},

--- a/test/exsyslog_test.exs
+++ b/test/exsyslog_test.exs
@@ -2,20 +2,21 @@ defmodule ExsyslogTest do
   use ExUnit.Case
 
   require Logger
+
   test "different level of logs" do
     debug_log = "debug log #{random_str()}"
-    Logger.debug debug_log
+    Logger.debug(debug_log)
 
     info_log = "info log #{random_str()}"
-    Logger.info info_log
+    Logger.info(info_log)
 
     error_log = "error log #{random_str()}"
-    Logger.error error_log
+    Logger.error(error_log)
   end
 
   def random_str do
     18
-    |> :crypto.strong_rand_bytes
-    |> Base.encode16
+    |> :crypto.strong_rand_bytes()
+    |> Base.encode16()
   end
 end


### PR DESCRIPTION
Changes needed for newer versions of Elixir.

Fixes:

```
warning: use Mix.Config is deprecated. Use the Config module instead
  config/config.exs:3

warning: use Mix.Config is deprecated. Use the Config module instead
  config/dev.exs:1
```

```
warning: :compile_time_purge_level option for the :logger application is deprecated, use :compile_time_purge_matching instead
  test/exsyslog_test.exs:7: ExsyslogTest."test different level of logs"/1

warning: :compile_time_purge_level option for the :logger application is deprecated, use :compile_time_purge_matching instead
  test/exsyslog_test.exs:10: ExsyslogTest."test different level of logs"/1

warning: :compile_time_purge_level option for the :logger application is deprecated, use :compile_time_purge_matching instead
  test/exsyslog_test.exs:13: ExsyslogTest."test different level of logs"/1
```