### PR TITLE
FIX / Log to syslog even when group leader is another node

### DIFF
--- a/lib/ex_syslogger.ex
+++ b/lib/ex_syslogger.ex
@@ -197,15 +197,6 @@ defmodule ExSyslogger do
     {:ok, :ok, new_state}
   end
 
-  @doc """
-  Handles a log event. Ignores the log event if the event level is less than the min log level.
-
-  Ignores messages where the group leader is in a different node.
-  """
-  def handle_event({_level, gl, _event}, config) when node(gl) != node() do
-    {:ok, config}
-  end
-
   def handle_event(
         {level, _gl, {Logger, msg, timestamp, metadata}},
         %{log: log, config: config} = state


### PR DESCRIPTION
This PR make ex_syslog logging consistent with the console and logger_file_backend. They log to local even when the group leader is not the on the current node for example, this maintains logging in situations like when rpc calls are being made to the node.  Currently ex_syslogger will not push these logs. This PR fixes this issue.

 