### PR TITLE
Fix Elixir 1.19 Logger deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [Unreleased]
+
+### Fixed
+- Resolve Elixir 1.19 / Logger deprecation warnings:
+  - Normalize the legacy `:warn` level to `:warning` before it reaches `Logger.compare_levels/2`, which was emitting a deprecation warning on every warning-level log.
+  - Remove the deprecated `$levelpad` token from the default format pattern, docs, and example configs.
+  - Replace the single-quoted `'#Ref'` charlist with the `~c"#Ref"` sigil in the JSON formatter.
+
 ## [2.1.0] - 2024-07-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ You might notice that instead of just passing the Module name, we're passing a t
 ```
 config :logger, :ex_syslogger_error,
   level: :error,
-  format: "$date $time [$level] $levelpad$node $metadata $message",
+  format: "$date $time [$level] $node $metadata $message",
   metadata: [:module, :line, :function],
   ident: "MyApplication",
   facility: :local0,
@@ -104,7 +104,7 @@ config :logger, :ex_syslogger_json,
 ### Backend configuration properties
 
 * __level__ (optional): the logging level. It defaults to `:info`
-* __format__ (optional): Same as `:console` backend ([Logger.Formatter](http://elixir-lang.org/docs/stable/logger/)). It defaults to `"\n$date $time [$level] $levelpad$node $metadata $message\n"`
+* __format__ (optional): Same as `:console` backend ([Logger.Formatter](http://elixir-lang.org/docs/stable/logger/)). It defaults to `"\n$date $time [$level] $node $metadata $message\n"`
 * __formatter__ (optional): Formatter that will be used to format the log. It default to Logger.Formatter
 * __metadata__ (optional): Same as `:console` backend [Logger.Formatter](http://elixir-lang.org/docs/stable/logger/). It defaults to `[]`
 * __ident__ (optional): A string that's prepended to every message, and is typically set to the app name. It defaults to `"Elixir"`

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -14,12 +14,12 @@ config :logger,
 
 config :logger, :console,
   level: :error,
-  format: "$date $time [$level] $levelpad$node $metadata $message\n",
+  format: "$date $time [$level] $node $metadata $message\n",
   metadata: [:module, :line, :function]
 
 config :logger, :ex_syslogger_error,
   level: :error,
-  format: "$date $time [$level] $levelpad$node $metadata $message",
+  format: "$date $time [$level] $node $metadata $message",
   metadata: [:module, :line, :function],
   ident: "MyApplication",
   facility: :local0,

--- a/examples/example1/config/config.exs
+++ b/examples/example1/config/config.exs
@@ -38,12 +38,12 @@ config :logger,
 
 config :logger, :console,
   level: :error,
-  format: "$date $time [$level] $levelpad$node $metadata $message\n",
+  format: "$date $time [$level] $node $metadata $message\n",
   metadata: [:module, :line, :function]
 
 config :logger, :ex_syslogger_error,
   level: :error,
-  format: "$date $time [$level] $levelpad$node $metadata $message",
+  format: "$date $time [$level] $node $metadata $message",
   metadata: [:module, :line, :function],
   ident: "MyApplication",
   facility: :local0,

--- a/lib/ex_syslogger.ex
+++ b/lib/ex_syslogger.ex
@@ -61,7 +61,7 @@ defmodule ExSyslogger do
   ```
   config :logger, :ex_syslogger_error,
     level: :error,
-    format: "$date $time [$level] $levelpad$node $metadata $message",
+    format: "$date $time [$level] $node $metadata $message",
     metadata: [:module, :line, :function],
     ident: "MyApplication",
     facility: :local0,
@@ -88,7 +88,7 @@ defmodule ExSyslogger do
   ### Backend configuration properties
 
   * __level__ (optional): the logging level. It defaults to `:info`
-  * __format__ (optional): Same as `:console` backend ([Logger.Formatter](http://elixir-lang.org/docs/stable/logger/)). It defaults to `"\n$date $time [$level] $levelpad$node $metadata $message\n"`
+  * __format__ (optional): Same as `:console` backend ([Logger.Formatter](http://elixir-lang.org/docs/stable/logger/)). It defaults to `"\n$date $time [$level] $node $metadata $message\n"`
   * __formatter__ (optional): Formatter that will be used to format the log. It default to Logger.Formatter
   * __metadata__ (optional): Same as `:console` backend [Logger.Formatter](http://elixir-lang.org/docs/stable/logger/). It defaults to `[]`
   * __ident__ (optional): A string that's prepended to every message, and is typically set to the app name. It defaults to `"Elixir"`
@@ -161,7 +161,7 @@ defmodule ExSyslogger do
 
   @behaviour :gen_event
 
-  @default_pattern "$date $time [$level] $levelpad$node $metadata $message\n"
+  @default_pattern "$date $time [$level] $node $metadata $message\n"
 
   @doc false
   def init({__MODULE__, name}) do
@@ -201,6 +201,7 @@ defmodule ExSyslogger do
         {level, _gl, {Logger, msg, timestamp, metadata}},
         %{log: log, config: config} = state
       ) do
+    level = normalize_level(level)
     min_level = config.level
 
     if is_nil(min_level) or Logger.compare_levels(level, min_level) != :lt do
@@ -218,9 +219,12 @@ defmodule ExSyslogger do
   #
   # Internal functions
 
+  defp normalize_level(:warn), do: :warning
+  defp normalize_level(level), do: level
+
   defp level_to_priority(:debug), do: :debug
   defp level_to_priority(:info), do: :info
-  defp level_to_priority(:warn), do: :warning
+  defp level_to_priority(:warning), do: :warning
   defp level_to_priority(:error), do: :err
 
   defp get_config(name, options) do
@@ -228,7 +232,7 @@ defmodule ExSyslogger do
     configs = Keyword.merge(env, options)
     Application.put_env(:logger, :ex_syslogger, configs)
 
-    level = Keyword.get(configs, :level, :info)
+    level = Keyword.get(configs, :level, :info) |> normalize_level()
     metadata = Keyword.get(configs, :metadata, [])
     facility = Keyword.get(configs, :facility, :local0)
     option = Keyword.get(configs, :option, :ndelay)

--- a/lib/ex_syslogger/json_formatter.ex
+++ b/lib/ex_syslogger/json_formatter.ex
@@ -93,7 +93,7 @@ defmodule ExSyslogger.JsonFormatter do
   end
 
   defp add_to_log({key, ref}, log) when is_reference(ref) do
-    '#Ref' ++ rest = :erlang.ref_to_list(ref)
+    ~c"#Ref" ++ rest = :erlang.ref_to_list(ref)
     Map.put(log, key, List.to_string(rest))
   end
 

--- a/test/exsyslog_test.exs
+++ b/test/exsyslog_test.exs
@@ -10,6 +10,9 @@ defmodule ExsyslogTest do
     info_log = "info log #{random_str()}"
     Logger.info(info_log)
 
+    warning_log = "warning log #{random_str()}"
+    Logger.warning(warning_log)
+
     error_log = "error log #{random_str()}"
     Logger.error(error_log)
   end


### PR DESCRIPTION
## What

Resolves the deprecation warnings emitted under Elixir 1.19 / recent
Logger versions. No behavior change beyond the warnings going away.

## Why

The legacy `:gen_event` backend layer delivers warning events using the
old `:warn` level name. Passing that atom to `Logger.compare_levels/2`
prints `the log level :warn is deprecated, use :warning instead` on
**every** warning-level log, flooding application logs.

## Changes

- Normalize the legacy `:warn` level to `:warning` before it reaches
  `Logger.compare_levels/2` (in both `handle_event/2` and the configured
  `min_level`); match `level_to_priority/1` on `:warning`.
- Remove the deprecated `$levelpad` token from the default format
  pattern, moduledoc, README, and example/dev configs.
- Replace the single-quoted `'#Ref'` charlist with the `~c"#Ref"` sigil
  in the JSON formatter.
- Add a warning-level log to the test suite, which previously only
  exercised debug/info/error and so never hit the `:warn` path.

## Out of scope

The `:backends` config key is also deprecated, but that originates from
consumer config and reflects the larger `:gen_event` → `:logger` handler
migration. Happy to discuss that separately if you'd like.

## Verified

`mix test` passes (now including a warning-level log); the three
deprecation warnings no longer appear during compile or test runs.
